### PR TITLE
Fixing Problem with setup:di:compile and some minor improvements

### DIFF
--- a/Block/Imprint/Content.php
+++ b/Block/Imprint/Content.php
@@ -23,17 +23,15 @@ class Content extends \Magento\Framework\View\Element\Template
 
     /**
      * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param ScopeConfigInterface                             $scopeConfig
      * @param array                                            $data
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
-        ScopeConfigInterface $scopeConfig,
         array $data = []
     )
     {
         parent::__construct($context, $data);
-        $this->scopeConfig = $scopeConfig;
+        $this->scopeConfig = $context->getScopeConfig();
     }
 
     /**
@@ -90,7 +88,7 @@ class Content extends \Magento\Framework\View\Element\Template
             return;
         }
 
-        $html = '<a href="#" onclick="javascript:toRecipient();">';
+        $html = '<a href="#" onclick="toRecipient();">';
         $html .= $parts[0] . '<span class="no-display">nospamplease</span>@<span class="no-display">nospamplease</span>' . $parts[1];
         $html .= '</a>';
         $html .= $this->getEmailJs($parts);

--- a/Test/Unit/Model/System/ConfigTest.php
+++ b/Test/Unit/Model/System/ConfigTest.php
@@ -5,12 +5,14 @@
  */
 namespace FireGento\MageSetup\Test\Unit\Model\System;
 
+use Magento\Framework\TestFramework\Unit\BaseTestCase;
+
 /**
  * Class Config
  *
  * @package FireGento\MageSetup\Test\Unit\Model\System
  */
-class Config extends \PHPUnit_Framework_TestCase
+class Config extends BaseTestCase
 {
     /**
      * @var \FireGento\MageSetup\Model\Config
@@ -21,10 +23,22 @@ class Config extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $scopeConfigMock = $this->getMock('\Magento\Framework\App\Config\ScopeConfigInterface');
-        $scopeConfigMock->expects($this->any())->method('getValue')->with($this->equalTo('general/country/eu_countries'))->will($this->returnValue('DE,AT'));
+        $scopeConfigMock = $this->getMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $scopeConfigMock->expects($this->any())->method('getValue')
+            ->with($this->equalTo('general/country/eu_countries'))
+            ->will($this->returnValue('DE,AT'));
 
-        $this->config = new \FireGento\MageSetup\Model\System\Config($scopeConfigMock);
+        $context = $this->getMock(\Magento\Framework\App\Helper\Context::class, [], [], '', false);
+        $context->expects($this->any())->method('getScopeConfig')->will($this->returnValue($scopeConfigMock));
+        /** @var \Magento\Framework\App\Helper\Context $context */
+
+        // $this->config = new \FireGento\MageSetup\Model\System\Config($context);
+        $this->config = $this->objectManager->getObject(
+            \FireGento\MageSetup\Model\System\Config::class,
+            [
+                'context' => $context
+            ]
+        );
     }
 
     /**

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -5,7 +5,8 @@
  * See LICENSE.md bundled with this module for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <block class="FireGento\MageSetup\Block\Price\Details" name="magesetup.product.price.details" as="price_details" template="FireGento_MageSetup::product/price/details.phtml"/>
     </body>


### PR DESCRIPTION
* Block/Imprint/Content.php was injected with context which already contains the ScopeConfig. The code was not failing, but di:compile was throwing an error, saying it was duplicate injection and therefore aborting
* fix Test/Unit/Model/System/ConfigTest.php and extend it from BaseTestCase
* fix namespace schema location in view/frontend/layout/default.xml