### PR TITLE
Hardened product list plugin against missing block

### DIFF
--- a/Plugin/Catalog/ListProductPlugin.php
+++ b/Plugin/Catalog/ListProductPlugin.php
@@ -34,6 +34,12 @@ class ListProductPlugin
         \Magento\Catalog\Model\Product $product)
     {
         $deliveryBlock = $subject->getLayout()->getBlock('product.info.delivery');
+
+        // Carry on with the default processing chain if the block does not exist.
+        if (!$deliveryBlock) {
+            return $proceed($product);
+        }
+
         $deliveryBlock->setProduct($product);
         $result = $proceed($product);
         if ((bool)$this->_scopeConfig->getValue(

--- a/Test/Unit/Plugin/Catalog/ListProductPluginTest.php
+++ b/Test/Unit/Plugin/Catalog/ListProductPluginTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright © 2016 FireGento e.V.
+ * See LICENSE.md bundled with this module for license details.
+ */
+
+namespace FireGento\MageSetup\Test\Unit\Plugin\Catalog;
+
+use FireGento\MageSetup\Plugin\Catalog\ListProductPlugin;
+use Magento\Catalog\Block\Product\ListProduct;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\View\LayoutInterface;
+
+class ListProductPluginTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ScopeConfigInterface | \PHPUnit_Framework_MockObject_MockObject */
+    protected $scopeConfigMock;
+
+    /** @var LayoutInterface | \PHPUnit_Framework_MockObject_MockObject */
+    protected $layoutMock;
+
+    /** @var ListProduct | \PHPUnit_Framework_MockObject_MockObject */
+    protected $listProductMock;
+
+    /** @var \Closure */
+    protected $proceedMock;
+
+    /** @var  ListProductPlugin */
+    protected $plugin;
+
+    /** @var Product | \PHPUnit_Framework_MockObject_MockObject */
+    protected $productMock;
+
+    public function setUp()
+    {
+        $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->plugin = new ListProductPlugin($this->scopeConfigMock);
+
+        $this->layoutMock = $this->getMockBuilder(LayoutInterface::class)
+            ->setMethods(['getBlock'])
+            ->getMockForAbstractClass();
+
+        $this->listProductMock = $this->getMockBuilder(ListProduct::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLayout'])
+            ->getMock();
+
+        $this->listProductMock->method('getLayout')
+            ->willReturn($this->layoutMock);
+
+        $this->proceedMock = function () {
+            return "HTML";
+        };
+
+        $this->productMock = $this->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Ensures that the plugin does not do anything stupid if the delivery
+     * info block is not present in the layout.
+     *
+     * @test
+     * @return void
+     */
+    public function aroundGetProductDetailsHtmlDoesNotDoAnythingIfBlockDoesNotExist()
+    {
+        // Simulate the situation when the block does not exist.
+        $this->layoutMock->expects($this->atLeastOnce())
+            ->method('getBlock')
+            ->with('product.info.delivery')
+            ->willReturn(false);
+
+        $result = $this->plugin->aroundGetProductDetailsHtml(
+            $this->listProductMock,
+            $this->proceedMock,
+            $this->productMock
+        );
+
+        // Make sure that the plugin does not modify the result.
+        $closure = $this->proceedMock;
+        $this->assertSame($result, $closure());
+    }
+
+}

--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -7,14 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="FireGento\MageSetup\Block\Product\Delivery" name="product.info.delivery" as="simple" template="FireGento_MageSetup::product/list/delivery.phtml">
-            <arguments>
-                <argument name="at_call" xsi:type="string">getDeliveryTime</argument>
-                <argument name="at_code" xsi:type="string">delivery_time</argument>
-                <argument name="css_class" xsi:type="string">delivery_time</argument>
-                <argument name="at_label" xsi:type="string">Delivery Time </argument>
-                <argument name="add_attribute" xsi:type="string">itemprop="delivery_time "</argument>
-            </arguments>
-        </block>
+        <update handle="catalog_delivery_info"/>
     </body>
 </page>

--- a/view/frontend/layout/catalog_delivery_info.xml
+++ b/view/frontend/layout/catalog_delivery_info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2016 FireGento e.V.
+ * See LICENSE.md bundled with this module for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <block class="FireGento\MageSetup\Block\Product\Delivery" name="product.info.delivery" as="simple" template="FireGento_MageSetup::product/list/delivery.phtml">
+            <arguments>
+                <argument name="at_call" xsi:type="string">getDeliveryTime</argument>
+                <argument name="at_code" xsi:type="string">delivery_time</argument>
+                <argument name="css_class" xsi:type="string">delivery_time</argument>
+                <argument name="at_label" xsi:type="string">Delivery Time </argument>
+                <argument name="add_attribute" xsi:type="string">itemprop="delivery_time "</argument>
+            </arguments>
+        </block>
+    </body>
+</page>

--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2016 FireGento e.V.
+ * See LICENSE.md bundled with this module for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <!-- Adding delivery information to the product list in search results. -->
+        <update handle="catalog_delivery_info"/>
+    </body>
+</page>


### PR DESCRIPTION
Hi guys!

On my installation firegento-magesetup2 would break the search results page with an exception about calling `setProduct` on `boolean` in `ListProductPlugin`. This only happens in production mode with `di` compiled.

The patch I submit adds a simple check if the block exists and a test for it. It also adds delivery data to the search result page to make rendering of delivery info in search results possible.
