### PR TITLE
Make imprint variables accessable as config variables in email templates

### DIFF
--- a/Plugin/Email/Block/Adminhtml/Template/Edit/Form.php
+++ b/Plugin/Email/Block/Adminhtml/Template/Edit/Form.php
@@ -15,6 +15,21 @@ use FireGento\MageSetup\Plugin\Email\Model\Source\Variables;
 class Form
 {
     /**
+     * Additional config variables
+     *
+     * @var \FireGento\MageSetup\Plugin\Email\Model\Source\Variables
+     */
+    private $variables;
+
+    /**
+     * Constructor
+     */
+    public function __construct(\FireGento\MageSetup\Plugin\Email\Model\Source\Variables $variables)
+    {
+        $this->variables = $variables;
+    }
+
+    /**
      * Retrieve variables to insert into email
      *
      * @param \Magento\Email\Block\Adminhtml\Template\Edit\Form $subject
@@ -24,7 +39,7 @@ class Form
      */
     public function afterGetVariables(\Magento\Email\Block\Adminhtml\Template\Edit\Form $subject, $result)
     {
-        $additionalConfigValues = Variables::getAdditionalConfigVariables();
+        $additionalConfigValues = $this->variables->getAdditionalConfigVariables();
         $optionArray = [];
         foreach ($additionalConfigValues as $variable) {
             $optionArray[] = [

--- a/Plugin/Email/Block/Adminhtml/Template/Edit/Form.php
+++ b/Plugin/Email/Block/Adminhtml/Template/Edit/Form.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © 2016 FireGento e.V.
+ * See LICENSE.md bundled with this module for license details.
+ */
+namespace FireGento\MageSetup\Plugin\Email\Block\Adminhtml\Template\Edit;
+
+use FireGento\MageSetup\Plugin\Email\Model\Source\Variables;
+
+/**
+ * Class Variables
+ *
+ * @package FireGento\MageSetup\Plugin\Email\Block\Adminhtml\Template\Edit
+ */
+class Form
+{
+    /**
+     * Retrieve variables to insert into email
+     *
+     * @param \Magento\Email\Block\Adminhtml\Template\Edit\Form $subject
+     * @param array $result
+     *
+     * @return array
+     */
+    public function afterGetVariables(\Magento\Email\Block\Adminhtml\Template\Edit\Form $subject, $result)
+    {
+        $additionalConfigValues = Variables::getAdditionalConfigVariables();
+        $optionArray = [];
+        foreach ($additionalConfigValues as $variable) {
+            $optionArray[] = [
+                'value' => '{{config path="' . $variable['value'] . '"}}',
+                'label' => $variable['label'],
+            ];
+        }
+        if ($optionArray) {
+            $result[] = [
+                'label' => __('Imprint'),
+                'value' => $optionArray,
+            ];
+        }
+        return $result;
+    }
+}

--- a/Plugin/Email/Model/Source/Variables.php
+++ b/Plugin/Email/Model/Source/Variables.php
@@ -10,16 +10,21 @@ namespace FireGento\MageSetup\Plugin\Email\Model\Source;
  *
  * @package FireGento\MageSetup\Plugin\Email\Model\Source
  */
-class Variables {
+class Variables
+{
+    /**
+     * Assoc array of configuration variables
+     *
+     * @var array
+     */
+    private $additionalConfigVariables = [];
 
     /**
-     * Returns additional config config variables
-     *
-     * @return array
+     * Constructor
      */
-    public static function getAdditionalConfigVariables()
+    public function __construct()
     {
-        return [
+        $this->additionalConfigVariables = [
             ['value' => 'general/imprint/shop_name', 'label' => __('Shop Name')],
             ['value' => 'general/imprint/company_first', 'label' => __('Company First')],
             ['value' => 'general/imprint/company_second', 'label' => __('Company Second')],
@@ -75,6 +80,16 @@ class Variables {
     }
 
     /**
+     * Returns additional config config variables
+     *
+     * @return array
+     */
+    public function getAdditionalConfigVariables()
+    {
+        return $this->additionalConfigVariables;
+    }
+
+    /**
      * Return available config variables
      *
      * @param \Magento\Email\Model\Source\Variables $subject
@@ -85,6 +100,6 @@ class Variables {
      */
     public function afterGetData(\Magento\Email\Model\Source\Variables $subject, $result)
     {
-        return array_merge($result, self::getAdditionalConfigVariables());
+        return array_merge($result, $this->getAdditionalConfigVariables());
     }
 }

--- a/Plugin/Email/Model/Source/Variables.php
+++ b/Plugin/Email/Model/Source/Variables.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © 2016 FireGento e.V.
+ * See LICENSE.md bundled with this module for license details.
+ */
+namespace FireGento\MageSetup\Plugin\Email\Model\Source;
+
+/**
+ * Class Variables
+ *
+ * @package FireGento\MageSetup\Plugin\Email\Model\Source
+ */
+class Variables {
+
+    /**
+     * Returns additional config config variables
+     *
+     * @return array
+     */
+    public static function getAdditionalConfigVariables()
+    {
+        return [
+            ['value' => 'general/imprint/shop_name', 'label' => __('Shop Name')],
+            ['value' => 'general/imprint/company_first', 'label' => __('Company First')],
+            ['value' => 'general/imprint/company_second', 'label' => __('Company Second')],
+            ['value' => 'general/imprint/street', 'label' => __('Street')],
+            ['value' => 'general/imprint/zip', 'label' => __('Zip')],
+            ['value' => 'general/imprint/city', 'label' => __('City')],
+            ['value' => 'general/imprint/country', 'label' => __('Default Country')],
+            ['value' => 'general/imprint/telephone', 'label' => __('Telephone')],
+            [
+                'value' => 'general/imprint/telephone_additional',
+                'label' => __('Supplementary Information for Telephone'),
+            ],
+            ['value' => 'general/imprint/fax', 'label' => __('Fax')],
+            ['value' => 'general/imprint/email', 'label' => __('Email')],
+            ['value' => 'general/imprint/web', 'label' => __('Website')],
+            ['value' => 'general/imprint/tax_number', 'label' => __('Tax number')],
+            ['value' => 'general/imprint/vat_id', 'label' => __('VAT-ID')],
+            ['value' => 'general/imprint/court', 'label' => __('Register Court')],
+            ['value' => 'general/imprint/financial_office', 'label' => __('Financial Office')],
+            ['value' => 'general/imprint/ceo', 'label' => __('CEO')],
+            ['value' => 'general/imprint/owner', 'label' => __('Owner')],
+            [
+                'value' => 'general/imprint/content_responsable_name',
+                'label' => __('Responsible for content'),
+            ],
+            [
+                'value' => 'general/imprint/content_responsable_address',
+                'label' => __('Responsible for content address'),
+            ],
+            [
+                'value' => 'general/imprint/content_responsable_press_law',
+                'label' => __('Responsible in the interests of the press law'),
+            ],
+            ['value' => 'general/imprint/register_number', 'label' => __('Register Number')],
+            [
+                'value' => 'general/imprint/business_rules',
+                'label' => __('Reference for business rules (physician, ...)'),
+            ],
+            ['value' => 'general/imprint/authority', 'label' => __('Authority (ECG)')],
+            ['value' => 'general/imprint/shareholdings', 'label' => __('Shareholdings')],
+            [
+                'value' => 'general/imprint/editorial_concept',
+                'label' => __('Editorial Concept'),
+            ],
+            ['value' => 'general/imprint/bank_account_owner', 'label' => __('Account owner')],
+            ['value' => 'general/imprint/bank_account', 'label' => __('Account')],
+            ['value' => 'general/imprint/bank_code_number', 'label' => __('Bank number')],
+            ['value' => 'general/imprint/bank_name', 'label' => __('Bank name')],
+            ['value' => 'general/imprint/swift', 'label' => __('BIC/Swift-Code')],
+            ['value' => 'general/imprint/iban', 'label' => __('IBAN')],
+            ['value' => 'general/imprint/clearing', 'label' => __('Clearing')],
+        ];
+    }
+
+    /**
+     * Return available config variables
+     *
+     * @param \Magento\Email\Model\Source\Variables $subject
+     * @param array $result
+     *
+     * @return array
+     * @codeCoverageIgnore
+     */
+    public function afterGetData(\Magento\Email\Model\Source\Variables $subject, $result)
+    {
+        return array_merge($result, self::getAdditionalConfigVariables());
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -48,4 +48,12 @@
         <plugin name="mageSetupProductDetailsHtml" type="FireGento\MageSetup\Plugin\Catalog\ListProductPlugin" sortOrder="1" />
     </type>
 
+    <type name="Magento\Email\Model\Source\Variables">
+        <plugin name="mageSetupEmailSourceVariables" type="FireGento\MageSetup\Plugin\Email\Model\Source\Variables"/>
+    </type>
+
+    <type name="Magento\Email\Block\Adminhtml\Template\Edit\Form">
+        <plugin name="mageSetupEmailAdminhtmlTemplateEditForm" type="FireGento\MageSetup\Plugin\Email\Block\Adminhtml\Template\Edit\Form"/>
+    </type>
+
 </config>


### PR DESCRIPTION
This PR makes the `general/imprint/*` config entries available as config variables in email templates.

![screenshot from 2016-10-05 13 08 45](https://cloud.githubusercontent.com/assets/1677744/19111127/29473ce6-8afe-11e6-986a-b2a93b27546d.png)
