### PR TITLE
remove alias from `product.info.delivery` layout definition

### DIFF
--- a/view/frontend/layout/catalog_delivery_info.xml
+++ b/view/frontend/layout/catalog_delivery_info.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="FireGento\MageSetup\Block\Product\Delivery" name="product.info.delivery" as="simple" template="FireGento_MageSetup::product/list/delivery.phtml">
+        <block class="FireGento\MageSetup\Block\Product\Delivery" name="product.info.delivery" template="FireGento_MageSetup::product/list/delivery.phtml">
             <arguments>
                 <argument name="at_call" xsi:type="string">getDeliveryTime</argument>
                 <argument name="at_code" xsi:type="string">delivery_time</argument>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [ ] README.md reflects changes (if applicable)
- [ ] New files contain a license header

### Issue

This PR fixes issue # .

### Proposed changes

alias `simple` removed because of collisions with aliases used for renderers in `category.product.type.details.renderers` layout definition.