### PR TITLE
Visible on checkout attribute labels

### DIFF
--- a/Plugin/Catalog/Helper/Product/Configuration/AroundGetCustomOptionsPlugin.php
+++ b/Plugin/Catalog/Helper/Product/Configuration/AroundGetCustomOptionsPlugin.php
@@ -45,14 +45,14 @@ class AroundGetCustomOptionsPlugin
 
         $attributes = $this->getVisibleCheckoutAttributesService->execute();
         if (count($attributes) > 0) {
-            foreach ($attributes as $attributeCode => $attributeLabel) {
-                $value = $item->getProduct()->getData($attributeCode);
+            foreach ($attributes as $attributeCode => $attribute) {
+                $value = $attribute->getFrontend()->getValue($item->getProduct());
                 if (!$value) {
                     continue;
                 }
 
                 $options[] = [
-                    'label'       => $attributeLabel,
+                    'label'       => $attribute->getStoreLabel(),
                     'value'       => $value,
                     'print_value' => $value
                 ];

--- a/Plugin/Catalog/Model/Attribute/AroundGetAttributeNamesPlugin.php
+++ b/Plugin/Catalog/Model/Attribute/AroundGetAttributeNamesPlugin.php
@@ -41,7 +41,7 @@ class AroundGetAttributeNamesPlugin
 
         if ($groupName == 'quote_item') {
             $attributes = $this->getVisibleCheckoutAttributesService->execute();
-            foreach ($attributes as $attributeCode => $attributeLabel) {
+            foreach ($attributes as $attributeCode => $attribute) {
                 $attributeNames[] = $attributeCode;
             }
         }

--- a/Service/GetVisibleCheckoutAttributesService.php
+++ b/Service/GetVisibleCheckoutAttributesService.php
@@ -46,9 +46,9 @@ class GetVisibleCheckoutAttributesService implements GetVisibleCheckoutAttribute
         $options = [];
         if (count($attributes->getItems()) > 0) {
             foreach ($attributes->getItems() as $attribute) {
-                /** @var \Magento\Catalog\Model\ResourceModel\Eav\Attribute $handle */
+                /** @var \Magento\Catalog\Model\ResourceModel\Eav\Attribute $attribute */
 
-                $options[$attribute->getAttributeCode()] = $attribute->getDefaultFrontendLabel();
+                $options[$attribute->getAttributeCode()] = $attribute;
             }
         }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [ ] README.md reflects changes (if applicable)
- [ ] New files contain a license header

### Issue

This PR fixes issue # .

### Proposed changes

when multiselect attributes are visible in checkout, their option-IDs were shown. Now the correct option labels are shown

before: 
> **Multi** 4, 5

after:
> **Multi** Eins, Zwei

