### PR TITLE
fix missing return when block was found and `catalog/frontend/display…

### DIFF
--- a/Plugin/Catalog/ListProductPlugin.php
+++ b/Plugin/Catalog/ListProductPlugin.php
@@ -33,21 +33,21 @@ class ListProductPlugin
         \Closure $proceed,
         \Magento\Catalog\Model\Product $product)
     {
+        $result = $proceed($product);
+
         $deliveryBlock = $subject->getLayout()->getBlock('product.info.delivery');
 
-        // Carry on with the default processing chain if the block does not exist.
-        if (!$deliveryBlock) {
-            return $proceed($product);
-        }
+        if ($deliveryBlock) {
+            $deliveryBlock->setProduct($product);
 
-        $deliveryBlock->setProduct($product);
-        $result = $proceed($product);
-        if ((bool)$this->_scopeConfig->getValue(
+            if ((bool) $this->_scopeConfig->getValue(
                 'catalog/frontend/display_delivery_time',
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             )) {
-;
-            return $deliveryBlock->toHtml() . $result;
+                $result = $deliveryBlock->toHtml() . $result;
+            }
         }
+
+        return $result;
     }
 }


### PR DESCRIPTION
…_delivery_time` is `0`

Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [ ] README.md reflects changes (if applicable)
- [ ] New files contain a license header

### Issue

This PR fixes issue # .

### Proposed changes

when `product.info.delivery` block was found and `catalog/frontend/display_delivery_time` was set to `0` no content was returned. 