### PR TITLE
Add configuration for Switzerland

### DIFF
--- a/Model/Setup/SubProcessor/TaxSubProcessor.php
+++ b/Model/Setup/SubProcessor/TaxSubProcessor.php
@@ -216,7 +216,7 @@ class TaxSubProcessor extends AbstractSubProcessor
             return $this->magesetupConfig->getEuCountries();
         }
 
-        return $this->config->getCountry();
+        return [$this->config->getCountry()];
     }
 
     /**

--- a/etc/magesetup.xml
+++ b/etc/magesetup.xml
@@ -194,7 +194,131 @@
         </blocks>
     </setup>
     <setup name="at"/>
-    <setup name="ch"/>
+    <setup name="ch">
+        <system_config>
+            <general__country__default>CH</general__country__default>
+            <tax__defaults__country>CH</tax__defaults__country>
+            <tax__defaults__region>129</tax__defaults__region>
+            <tax__defaults__postcode>8001</tax__defaults__postcode>
+            <shipping__origin__country_id>CH</shipping__origin__country_id>
+            <shipping__origin__region_id>129</shipping__origin__region_id>
+            <shipping__origin__postcode>8001</shipping__origin__postcode>
+            <shipping__origin__city>Zürich</shipping__origin__city>
+            <sales__reorder__allow>1</sales__reorder__allow>
+        </system_config>
+        <tax>
+            <tax_calculation_rules>
+                <products_full_tax tax_rate="tax_calculation_rate_1"
+                                   tax_customer_class="customers_end_users,customers_companies"
+                                   tax_product_class="products_rate_1,shipping_rate_1">
+                    <code>Kunden kaufen vollbesteuerte Artikel</code>
+                    <priority>1</priority>
+                    <position>0</position>
+                    <calculate_subtotal>0</calculate_subtotal>
+                </products_full_tax>
+                <products_reduced_tax tax_rate="tax_calculation_rate_2"
+                                      tax_customer_class="customers_end_users,customers_companies"
+                                      tax_product_class="products_rate_2">
+                    <code>Kunden kaufen ermässigtbesteuerte Artikel</code>
+                    <priority>2</priority>
+                    <position>0</position>
+                    <calculate_subtotal>0</calculate_subtotal>
+                </products_reduced_tax>
+                <products_no_vat tax_rate="tax_calculation_rate_3"
+                                 tax_customer_class="customers_companies_no_vat"
+                                 tax_product_class="products_rate_1,products_rate_2,shipping_rate_1">
+                    <code>MwSt.-befreite Unternehmen kaufen voll- und ermässigtbesteuerte Artikel</code>
+                    <priority>3</priority>
+                    <position>0</position>
+                    <calculate_subtotal>0</calculate_subtotal>
+                </products_no_vat>
+            </tax_calculation_rules>
+            <tax_classes>
+                <products_rate_1>
+                    <class_id>1</class_id>
+                    <class_name>Vollbesteuerte Artikel</class_name>
+                    <class_type>PRODUCT</class_type>
+                </products_rate_1>
+                <products_rate_2>
+                    <class_id>2</class_id>
+                    <class_name>Ermässigtbesteuerte Artikel</class_name>
+                    <class_type>PRODUCT</class_type>
+                </products_rate_2>
+                <shipping_rate_1>
+                    <class_id>3</class_id>
+                    <class_name>Vollbesteuerter Versand</class_name>
+                    <class_type>PRODUCT</class_type>
+                </shipping_rate_1>
+                <customers_end_users>
+                    <class_id>5</class_id>
+                    <class_name>Endkunden</class_name>
+                    <class_type>CUSTOMER</class_type>
+                </customers_end_users>
+                <customers_companies>
+                    <class_id>6</class_id>
+                    <class_name>MwSt.-pflichtige Unternehmen</class_name>
+                    <class_type>CUSTOMER</class_type>
+                </customers_companies>
+                <customers_companies_no_vat>
+                    <class_id>7</class_id>
+                    <class_name>MwSt.-befreite Unternehmen</class_name>
+                    <class_type>CUSTOMER</class_type>
+                </customers_companies_no_vat>
+            </tax_classes>
+            <tax_calculation_rates>
+                <tax_calculation_rate_1>
+                    <tax_region_id>0</tax_region_id>
+                    <tax_postcode>*</tax_postcode>
+                    <label>MwSt.</label>
+                    <rate>8</rate>
+                </tax_calculation_rate_1>
+                <tax_calculation_rate_2>
+                    <tax_region_id>0</tax_region_id>
+                    <tax_postcode>*</tax_postcode>
+                    <label>reduzierte MwSt.</label>
+                    <rate>2.5</rate>
+                </tax_calculation_rate_2>
+                <tax_calculation_rate_3>
+                    <tax_region_id>0</tax_region_id>
+                    <tax_postcode>*</tax_postcode>
+                    <label>ohne UMwStSt.</label>
+                    <rate>0</rate>
+                </tax_calculation_rate_3>
+            </tax_calculation_rates>
+        </tax>
+        <agreements>
+            <business_terms>
+                <is_active>1</is_active>
+                <is_html>1</is_html>
+                <mode>1</mode>
+                <filename>business_terms.html</filename>
+            </business_terms>
+        </agreements>
+        <pages>
+            <magesetup_404>
+                <filename>404.html</filename>
+            </magesetup_404>
+            <magesetup_payment>
+                <filename>payment.html</filename>
+            </magesetup_payment>
+            <magesetup_shipping>
+                <filename>shipping.html</filename>
+                <config_option>catalog/price/cms_page_shipping</config_option>
+            </magesetup_shipping>
+            <magesetup_order>
+                <filename>order.html</filename>
+            </magesetup_order>
+            <magesetup_business_terms>
+                <filename>business_terms.html</filename>
+            </magesetup_business_terms>
+        </pages>
+        <blocks>
+            <business_terms>
+                <identifier>business_terms</identifier>
+                <filename>business_terms.html</filename>
+            </business_terms>
+        </blocks>
+    </setup>
     <setup name="es"/>
     <setup name="fr"/>
     <setup name="gb"/>

--- a/etc/magesetup.xml
+++ b/etc/magesetup.xml
@@ -281,7 +281,7 @@
                 <tax_calculation_rate_3>
                     <tax_region_id>0</tax_region_id>
                     <tax_postcode>*</tax_postcode>
-                    <label>ohne UMwStSt.</label>
+                    <label>ohne MwSt.</label>
                     <rate>0</rate>
                 </tax_calculation_rate_3>
             </tax_calculation_rates>


### PR DESCRIPTION
### Issue

This PR fixes a part of issue #26.

### Proposed changes

The section for `ch` was added in the magesetup.xml.
Additional, a bug was fixed which occured during setup if a non-EU country was selected.
