### PR TITLE
Fix warning on search result page

### DIFF
--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -6,8 +6,6 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body>
-        <!-- Adding delivery information to the product list in search results. -->
-        <update handle="catalog_delivery_info"/>
-    </body>
+    <!-- Adding delivery information to the product list in search results. -->
+    <update handle="catalog_delivery_info"/>
 </page>


### PR DESCRIPTION
< update > tag needs to be outside < body >, an error is shown otherwise in v2.2