### PR TITLE
Enable usage with php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "firegento/magesetup2",
   "description": "MageSetup provides the necessary configuration (system config, tax, agreements, etc. for a national market.",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
     "magento/module-store": "*",
     "magento/module-backend": "*",
     "magento/framework": "*"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

As Magento 2.2 per release notes now supports PHP 7.1 this module should also be made compatible.
http://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.0EE.html

The readme.md already states compatibility with PHP >= 5.5.0

### Proposed changes

Add PHP 7.1 in composer.json require clause
