### PR TITLE
Magento 2.2+ does not allow update Element here

### DIFF
--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -6,8 +6,7 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body>
-        <!-- Adding delivery information to the product list in search results. -->
-        <update handle="catalog_delivery_info"/>
-    </body>
+    <!-- Adding delivery information to the product list in search results. -->
+    <update handle="catalog_delivery_info"/>
+    <body/>
 </page>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [ x] Pull request is based against develop branch
- [ x] README.md reflects changes (if applicable)
- [x ] New files contain a license header

### Issue

This PR fixes issue #92  .

**General**

Magento version: 2.2.1

**Issue description**

When upgrading to Magento 2.2 the layout.xml checking is improved and throws errors when xml-files are not correctly formatted. The problem persists in File catalogsearch_result_index.xml because update Node is inside of body Node.

**Steps to reproduce**

Install Magento 2.2 or Update from earlier Version
Install FireGento MageSetup2
Perform Search