### PR TITLE
fix tier price template creation dependencies

### DIFF
--- a/view/frontend/web/js/configurable.js
+++ b/view/frontend/web/js/configurable.js
@@ -2,7 +2,12 @@
  * Copyright © 2017 FireGento e.V.
  * See LICENSE.md bundled with this module for license details.
  */
-define(['jquery'], function ($) {
+define([
+    'jquery',
+    'mage/template',
+    'mage/translate',
+    'priceUtils'
+], function ($, mageTemplate, $t, priceUtils) {
     'use strict';
 
     return function (target) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

No issue created

### Proposed changes

Necessary "requirejs" dependencies were missing so a tier price template could not be created on configurable product view. This produced a javascript error where "mageTemplate" were not defined.

  