### PR TITLE
Fix tax details rendering for tier prices

### DIFF
--- a/Plugin/Pricing/AroundRenderPlugin.php
+++ b/Plugin/Pricing/AroundRenderPlugin.php
@@ -42,7 +42,17 @@ class AroundRenderPlugin
         array $arguments = []
     ) {
         $returnValue = $proceed($priceCode, $saleableItem, $arguments);
-        if (trim($returnValue) != '') {
+        // if there is anything returned we should render the price details
+        $shouldRender = trim($returnValue) != '';
+        // tier price returns JavaScript template, so check if item actually
+        // has tier prices
+        if ($priceCode === 'tier_price') {
+            $tierPrices = $saleableItem->getTierPrices();
+            $shouldRender = $tierPrices !== null &&
+                            is_array($tierPrices) &&
+                            count($tierPrices) > 0;
+        }
+        if ($shouldRender) {
             $block = $subject->getLayout()->getBlock('magesetup.product.price.details');
             if ($block) {
                 $block->setSaleableItem($saleableItem);


### PR DESCRIPTION
- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #87  .

### Proposed changes

This adds an extra check if tax details are rendered for tier prices and if so it'll check if the item actually has tier prices set.
