### PR TITLE
Hide tax details for grouped product

### DIFF
--- a/Plugin/Pricing/AroundRenderPlugin.php
+++ b/Plugin/Pricing/AroundRenderPlugin.php
@@ -61,7 +61,7 @@ class AroundRenderPlugin
         if (!$this->helper->getConfigValue(self::ENABLED_DISPLAY_BELOW_PRICE_XML)) {
             return $returnValue;
         }
-        if (trim($returnValue) != '') {
+        if (trim($returnValue) != '' && $saleableItem->getTypeId() !== 'grouped') {
             $block = $subject->getLayout()->getBlock('magesetup.product.price.details');
             if ($block) {
                 $block->setSaleableItem($saleableItem);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [X] Pull request is based against develop branch
- [X] README.md reflects changes (if applicable)
- [X] New files contain a license header

### Issue

This PR fixes issue #150.

### Proposed changes
The tax hint should not be shown for the main grouped products - only for the child products of the grouped product.

I did **not** use the constant `\Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE` to avoid a dependency on the grouped product module.