### PR TITLE
Update Details.php - Andere Steuersätze anzeigen

### DIFF
--- a/Block/Price/Details.php
+++ b/Block/Price/Details.php
@@ -164,8 +164,11 @@ class Details extends \Magento\Framework\View\Element\Template
                 $groupId = $this->customerSession->getCustomerGroupId();
                 $group = $this->groupRepository->getById($groupId);
                 $customerTaxClassId = $group->getTaxClassId();
-
-                $request = $this->taxCalculation->getRateRequest(null, null, $customerTaxClassId, $store);
+                $customerId = null;
+                if($this->customerSession->isLoggedIn())
+                    $customerId = $this->customerSession->getCustomerId();
+                    
+                $request = $this->taxCalculation->getRateRequest(null, null, $customerTaxClassId, $store, $customerId);
                 $request->setData('product_class_id', $productTaxClassId);
 
                 $taxPercent = $this->taxCalculation->getRate($request);


### PR DESCRIPTION
Unter Umständen haben Shops für bestimmte Länder andere Steuersätze hinterlegt (z.B. wenn Sie dort eine Umsatzsteuernummer angemeldet haben bzw. einen Firmensitz).
Bis jetzt wurde dieser Fall hier nicht berücksichtigt. 
Beispiel:
Kunde aus Finnland (Für Finnland sind 25% MwSt. als Steuersatz hinterlegt)
In Magento werden die Preise automatisch mit 25% MwSt. berechnet aber der Text (preis-details) zeigt immer noch 19% MwSt.!

Wäre mit der kleinen Änderung gelöst.

Please make sure these boxes are checked before submitting your PR - thank you!

- [ ] Pull request is based against develop branch
- [ ] README.md reflects changes (if applicable)
- [ ] New files contain a license header

### Issue

This PR fixes issue # .

### Proposed changes

... 
