### PR TITLE
Fix attribute group

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -72,7 +72,7 @@ class InstallData implements InstallDataInterface
                 'required'                => false,
                 'used_in_product_listing' => true,
                 'apply_to'                => $productTypes,
-                'group'                   => 'General',
+                'group'                   => 'Product Details',
                 'unique'                  => false,
                 'is_html_allowed_on_front'=> true,
                 'visible_on_front'        => true,

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -75,7 +75,7 @@ class UpgradeData implements UpgradeDataInterface
                 'required'                => false,
                 'used_in_product_listing' => true,
                 'apply_to'                => $productTypes,
-                'group'                   => 'General',
+                'group'                   => 'Product Details',
                 'unique'                  => false,
                 'is_html_allowed_on_front'=> true,
                 'visible_on_front'        => true,


### PR DESCRIPTION
This pull request fixes the unwanted renaming of the attribute group with the `attribute_group_code ` `product-details`.
To see that, just run a clean M2 installation and check `attribute_group_name` in table `eav_attribute_code` where `attribute_group_code ` = `product-details`.
You will see, that this group is initially called `Product Details`.
Now add this module and install Magento again. The name will be changed to `General`, which is surely not wanted.
See `\Magento\Tax\Setup\Patch\Data\AddTaxAttributeAndTaxClasses` to see, that Magento itself does it in this way.
The renaming of the group leads to critical issues for the Data Migration Module and removes all product attribute values in the M1 General Group completely during the migration.
See https://github.com/magento/data-migration-tool/issues/832 and https://github.com/magento/data-migration-tool/issues/817 for details.