### PR TITLE
[FEATURE] display attribute value of child product in cart

### DIFF
--- a/Plugin/Catalog/Helper/Product/Configuration/AddVisibleInCheckoutAttributesToCustomOptionsPlugin.php
+++ b/Plugin/Catalog/Helper/Product/Configuration/AddVisibleInCheckoutAttributesToCustomOptionsPlugin.php
@@ -9,6 +9,8 @@ namespace FireGento\MageSetup\Plugin\Catalog\Helper\Product\Configuration;
 use FireGento\MageSetup\Service\GetVisibleCheckoutAttributesServiceInterface;
 use Magento\Catalog\Helper\Product\Configuration;
 use Magento\Catalog\Model\Product\Configuration\Item\ItemInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
 
 /**
  * Plugin to add visible in checkout attributes to the custom option list.
@@ -21,13 +23,22 @@ class AddVisibleInCheckoutAttributesToCustomOptionsPlugin
     private $getVisibleCheckoutAttributesService;
 
     /**
+     * @var Json
+     */
+    private $json;
+
+    /**
      * AroundGetCustomOptionsPlugin constructor.
      *
      * @param GetVisibleCheckoutAttributesServiceInterface $getVisibleCheckoutAttributesService
+     * @param Json $json
      */
-    public function __construct(GetVisibleCheckoutAttributesServiceInterface $getVisibleCheckoutAttributesService)
-    {
+    public function __construct(
+        GetVisibleCheckoutAttributesServiceInterface $getVisibleCheckoutAttributesService,
+        Json $json
+    ) {
         $this->getVisibleCheckoutAttributesService = $getVisibleCheckoutAttributesService;
+        $this->json = $json;
     }
 
     /**
@@ -41,12 +52,40 @@ class AddVisibleInCheckoutAttributesToCustomOptionsPlugin
      */
     public function afterGetCustomOptions(Configuration $configuration, array $customOptions, ItemInterface $item)
     {
+        $product = $item->getProduct();
+
+        if (!$product) {
+            return [];
+        }
+
+        $configurableAttributes = $item->getOptionByCode('attributes')
+            ? $item->getOptionByCode('attributes')->getValue()
+            : [];
+        $configurableAttributes = is_string($configurableAttributes)
+            ? array_keys($this->json->unserialize($configurableAttributes) ?: [])
+            : [];
+
         $attributes = $this->getVisibleCheckoutAttributesService->execute();
         foreach ($attributes as $attributeCode => $attribute) {
+            $attributeFrontend = $attribute->getFrontend();
             if ($attributeCode === 'sku') {
-                $value = $item->getProduct()->getSku();
+                $value = $product->getSku();
             } else {
-                $value = $attribute->getFrontend()->getValue($item->getProduct());
+                $value = $attributeFrontend->getValue($product);
+            }
+
+            if ($item instanceof AbstractItem && $product->getTypeId() === 'configurable') {
+                if (in_array($attribute->getId(), $configurableAttributes) || !count($item->getChildren())) {
+                    // attribute is a configurable attribute. Magento will output it separately
+                    // or item has no children (but this should never occur)
+                    continue;
+                }
+
+                $children = $item->getChildren();
+                if ($children[0] instanceof AbstractItem && $children[0]->getProduct()) {
+                    // fetch the attribute value of the child
+                    $value = $attributeFrontend->getValue($children[0]->getProduct()) ?: $value;
+                }
             }
 
             if (!$value) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

none

### Proposed changes

this PR prints the child-attribute value in the cart instead of the configurable attribute value. 
This makes more sense, cause the admin would change the value in the child below. E.g. the SKU. 
