### PR TITLE
add php 8.3 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "firegento/magesetup2",
   "description": "MageSetup provides the necessary configuration (system config, tax, agreements, etc. for a national market.",
   "require": {
-    "php": "~7.3.0||~7.4.0||~8.1.0||~8.2.0",
+    "php": "~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0",
     "magento/module-store": "*",
     "magento/module-backend": "*",
     "magento/framework": ">=103.0.3"


### PR DESCRIPTION
add php8.3 compat (#221 )

scanned via phpcs php-compatility.
=> no errors, no-warnings

```bash
phpcs -p . --standard=PHPCompatibility --runtime-set testVersion 7.3-

............................................ 44 / 44 (100%)


Time: 1.56 secs; Memory: 18MB

```