### PR TITLE
respect bundle dynamic-sku

### DIFF
--- a/Plugin/Catalog/Helper/Product/Configuration/AddVisibleInCheckoutAttributesToCustomOptionsPlugin.php
+++ b/Plugin/Catalog/Helper/Product/Configuration/AddVisibleInCheckoutAttributesToCustomOptionsPlugin.php
@@ -42,8 +42,13 @@ class AddVisibleInCheckoutAttributesToCustomOptionsPlugin
     public function afterGetCustomOptions(Configuration $configuration, array $customOptions, ItemInterface $item)
     {
         $attributes = $this->getVisibleCheckoutAttributesService->execute();
-        foreach ($attributes as $attribute) {
-            $value = $attribute->getFrontend()->getValue($item->getProduct());
+        foreach ($attributes as $attributeCode => $attribute) {
+            if ($attributeCode === 'sku') {
+                $value = $item->getProduct()->getSku();
+            } else {
+                $value = $attribute->getFrontend()->getValue($item->getProduct());
+            }
+
             if (!$value) {
                 continue;
             }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Proposed changes

if the store owner mark the SKU as `visible in checkout` the attribute-value will be directly used for the SKU, instead of calling `getSku`, which does have a registered plugin within the `magento/module-bundle`.

With this change the correct SKU got displayed within the checkout
