### PR TITLE
checkout: prevent configurable fallback on "0"-value

### DIFF
--- a/Plugin/Catalog/Helper/Product/Configuration/AddVisibleInCheckoutAttributesToCustomOptionsPlugin.php
+++ b/Plugin/Catalog/Helper/Product/Configuration/AddVisibleInCheckoutAttributesToCustomOptionsPlugin.php
@@ -84,7 +84,10 @@ class AddVisibleInCheckoutAttributesToCustomOptionsPlugin
                 $children = $item->getChildren();
                 if ($children[0] instanceof AbstractItem && $children[0]->getProduct()) {
                     // fetch the attribute value of the child
-                    $value = $attributeFrontend->getValue($children[0]->getProduct()) ?: $value;
+                    $childValue = $attributeFrontend->getValue($children[0]->getProduct());
+                    // Be careful: "0" is a valid value for setting a yes/no attribute to false, so the check must be
+                    // against explicit null
+                    $value = $childValue === null ? $value : $childValue;
                 }
             }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Proposed changes

Fix handling of child product attributes with falsy values.

The previous ?: fallback treated "0" as empty and incorrectly replaced valid false values from the child product with the parent value.

This change introduces an explicit null check to ensure that valid yes/no attribute values (including "0") are preserved.
