### PR TITLE
Fix PHP 8.4 execute() return type and add PHP 8.5 / Magento 2.4.9 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,3 +117,32 @@ jobs:
           composer_name: firegento/magesetup2
           magento_version: '2.4.8'
           composer_version: '2'
+  integration-tests-249:
+    name: Magento 2 Integration Tests (Magento 2.4.9)
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --tmpfs /tmp:rw --tmpfs /var/lib/mysql:rw --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      es:
+        image: docker.io/wardenenv/opensearch:3.4
+        ports:
+          - 9200:9200
+        env:
+          'discovery.type': single-node
+          'plugins.security.disabled': 'true'
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'admin-Magento1234'
+          ES_JAVA_OPTS: "-Xms64m -Xmx512m"
+        options: --health-cmd="curl localhost:9200/_cluster/health?wait_for_status=yellow&timeout=60s" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - name: M2 Integration Tests with Magento 2 Version 2.4.9 (PHP 8.5)
+        uses: extdn/github-actions-m2/magento-integration-tests/8.5@master
+        with:
+          module_name: FireGento_MageSetup
+          composer_name: firegento/magesetup2
+          magento_version: '2.4.9'
+          composer_version: '2'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -110,6 +110,7 @@ jobs:
           ES_JAVA_OPTS: "-Xms64m -Xmx512m"
         options: --health-cmd="curl localhost:9200/_cluster/health?wait_for_status=yellow&timeout=60s" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
+      - uses: actions/checkout@v4
       - name: M2 Integration Tests with Magento 2 Version 2.4.8 (PHP 8.4)
         uses: extdn/github-actions-m2/magento-integration-tests/8.4@master
         with:
@@ -139,6 +140,7 @@ jobs:
           ES_JAVA_OPTS: "-Xms64m -Xmx512m"
         options: --health-cmd="curl localhost:9200/_cluster/health?wait_for_status=yellow&timeout=60s" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
+      - uses: actions/checkout@v4
       - name: M2 Integration Tests with Magento 2 Version 2.4.9 (PHP 8.5)
         uses: extdn/github-actions-m2/magento-integration-tests/8.5@master
         with:

--- a/Command/SetupRunCommand.php
+++ b/Command/SetupRunCommand.php
@@ -110,7 +110,7 @@ class SetupRunCommand extends Command
      * @param OutputInterface $output
      * @return int Non zero if invalid type, 0 otherwise
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $area = $this->appState->getAreaCode();

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "firegento/magesetup2",
   "description": "MageSetup provides the necessary configuration (system config, tax, agreements, etc. for a national market.",
   "require": {
-    "php": "~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0",
+    "php": "~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0||~8.5.0",
     "magento/module-store": "*",
     "magento/module-backend": "*",
     "magento/framework": ">=103.0.3"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

No related issue.

### Proposed changes

  - Fix PHP 8.4 fatal in `Command/SetupRunCommand::execute()`: add `int` return type
    (PHP 8.4 enforces the tentative return type from `Symfony\Console\Command\Command::execute()`).
  - Bump `composer.json` PHP/Magento constraints to include PHP 8.5 and Magento 2.4.9.
  - Extend GitHub Actions integration workflow with PHP 8.4/8.5 and Magento 2.4.9 matrix entries.
